### PR TITLE
Fix broken link to Feedback in FAQ

### DIFF
--- a/src/page/faq.html
+++ b/src/page/faq.html
@@ -2,7 +2,7 @@
 <a class="h1" href="@SELF@">About & FAQ</a>
 
 <p>
-	I'll be writing more about <a href="https://github.com/postmarketOS/">postmarketOS</a> and related topics, such as <a href="https://alpinelinux.org/">Alpine Linux</a> and maybe <a href="https://halium.org/">Halium</a> on this blog. But also about experiments with <a href="@WEBROOT@/page/donate/">crowdfunding</a> the whole thing to make it my next day job. Feel free to <a href="@WEBROOT@/pages/feedback/">write</a> me more questions.
+	I'll be writing more about <a href="https://github.com/postmarketOS/">postmarketOS</a> and related topics, such as <a href="https://alpinelinux.org/">Alpine Linux</a> and maybe <a href="https://halium.org/">Halium</a> on this blog. But also about experiments with <a href="@WEBROOT@/page/donate/">crowdfunding</a> the whole thing to make it my next day job. Feel free to <a href="@WEBROOT@/page/feedback/">write</a> me more questions.
 </p>
 
 <h2>Any plans to collaborate with <a href="https://halium.org/">Halium</a>?</h2>


### PR DESCRIPTION
FAQ page has a broken link to Feedback: this should hopefully fix it.

I haven't tested since I'm editing on the web ui and can't rebuild the final pages.